### PR TITLE
Swap Charting to Seaborn/Pandas

### DIFF
--- a/RedditComponent/graph.py
+++ b/RedditComponent/graph.py
@@ -45,26 +45,26 @@ def uploadImage():
 	submitReddit(theUrl)
 	
 def drawGraph(x, y1, y2):
-    x = pd.to_datetime(pd.Series(x)).dt.strftime('%b-%d') # Clean Up X Labels
-    
-    fig, axs = plt.subplots(facecolor='w', nrows=2) # Set Up Figure and Subplots
-    
-    sns.barplot(x=x, y=y1, color=sns.color_palette()[0], ax=axs[0]) # Plot Barplots
-    sns.barplot(x=x, y=y2, color=sns.color_palette()[0], ax=axs[1])
-    
-    axs[0].set_ylabel('Yes Votes') # Clean Y Labels
-    axs[1].set_ylabel('No Votes')
-    
-    max_y = max(max(y1),max(y2)) # Synchronize Axes
-    axs[0].set_ylim(0,max_y)
-    axs[1].set_ylim(0,max_y)
-    
-    plt.tight_layout() # Clean Suptitle
-    fig.suptitle('Weekly Voting Data', y=1.03)
+    	x = pd.to_datetime(pd.Series(x)).dt.strftime('%b-%d') # Clean Up X Labels
+    	
+    	fig, axs = plt.subplots(facecolor='w', nrows=2) # Set Up Figure and Subplots
+    	
+    	sns.barplot(x=x, y=y1, color=sns.color_palette()[0], ax=axs[0]) # Plot Barplots
+    	sns.barplot(x=x, y=y2, color=sns.color_palette()[0], ax=axs[1])
+    	
+    	axs[0].set_ylabel('Yes Votes') # Clean Y Labels
+    	axs[1].set_ylabel('No Votes')
+    	
+    	max_y = max(max(y1),max(y2)) # Synchronize Axes
+    	axs[0].set_ylim(0,max_y)
+    	axs[1].set_ylim(0,max_y)
+    	
+    	plt.tight_layout() # Clean Suptitle
+    	fig.suptitle('Weekly Voting Data', y=1.03)
 	
-    plt.savefig('/home/pi/Documents/weeklyData.png') # save file
+    	plt.savefig('/home/pi/Documents/weeklyData.png') # save file
 	
-    uploadImage()
+    	uploadImage()
 
 #plt.show()
 

--- a/RedditComponent/graph.py
+++ b/RedditComponent/graph.py
@@ -1,5 +1,7 @@
 import matplotlib.pyplot as plt
+import seaborn as sns
 import csv
+import pandas as pd
 import numpy as np
 import praw
 from imgurAuth import authenticate
@@ -7,6 +9,7 @@ from redditAuth import auth
 from datetime import datetime
 import os
 
+sns.set()
 
 def submitReddit(theUrl):
 	
@@ -40,23 +43,28 @@ def uploadImage():
 	theUrl = image['link']
 	print("Done")
 	submitReddit(theUrl)
-
+	
 def drawGraph(x, y1, y2):
-	plt.figure() # begin drawing a fig
-	plt.suptitle('Weekly Voting Data')
-	plt.subplot(211) # subplot of yes votes
-	plt.ylabel('yes votes')
-	plt.yticks(np.arange(0, (max(y1))+1, 1)) # make the y axis tick up by 1 all the day up to max val
-	plt.bar(x, y1)
-
-	plt.subplot(212) # subplot of no votes
-	plt.ylabel('no votes')
-	plt.yticks(np.arange(0, (max(y2))+1, 1)) # make the y axis tick up by 1 all the day up to max val
-	plt.bar(x, y2)
+    x = pd.to_datetime(pd.Series(x)).dt.strftime('%b-%d') # Clean Up X Labels
+    
+    fig, axs = plt.subplots(facecolor='w', nrows=2) # Set Up Figure and Subplots
+    
+    sns.barplot(x=x, y=y1, color=sns.color_palette()[0], ax=axs[0]) # Plot Barplots
+    sns.barplot(x=x, y=y2, color=sns.color_palette()[0], ax=axs[1])
+    
+    axs[0].set_ylabel('Yes Votes') # Clean Y Labels
+    axs[1].set_ylabel('No Votes')
+    
+    max_y = max(max(y1),max(y2)) # Synchronize Axes
+    axs[0].set_ylim(0,max_y)
+    axs[1].set_ylim(0,max_y)
+    
+    plt.tight_layout() # Clean Suptitle
+    fig.suptitle('Weekly Voting Data', y=1.03)
 	
-	plt.savefig('/home/pi/Documents/weeklyData.png') # save file
+    plt.savefig('/home/pi/Documents/weeklyData.png') # save file
 	
-	uploadImage()
+    uploadImage()
 
 #plt.show()
 

--- a/RedditComponent/graph.py
+++ b/RedditComponent/graph.py
@@ -55,14 +55,14 @@ def drawGraph(x, y1, y2):
     	axs[0].set_ylabel('Yes Votes') # Clean Y Labels
     	axs[1].set_ylabel('No Votes')
     	
-    	max_y = max(max(y1),max(y2)) # Synchronize Axes
+    	max_y = max(max(y1),max(y2))+1 # Synchronize Axes
     	axs[0].set_ylim(0,max_y)
     	axs[1].set_ylim(0,max_y)
     	
     	plt.tight_layout() # Clean Suptitle
     	fig.suptitle('Weekly Voting Data', y=1.03)
 	
-    	plt.savefig('/home/pi/Documents/weeklyData.png') # save file
+    	plt.savefig('/home/pi/Documents/weeklyData.png', bbox_inches='tight') # save file
 	
     	uploadImage()
 


### PR DESCRIPTION
Updates graph.py to use Pandas and Seaborn to plot weekly results. New method should be robust to the number of days (within reason), uses the subplots method to generate fig and axes for Seaborn. Dates parsed using Pandas.

Sample chart looks like this:
![image](https://user-images.githubusercontent.com/14115132/111839530-50331700-88d1-11eb-8c3c-0afebcc7c3f0.png)

Note, I cannot run a full test of this, but did recreate it in my own environment. You may need to install Seaborn if you get an import error, but this is a standard extension library to matplotlib/pyplot.

Please let me know how I can help with this project or if you want some more changes to this!